### PR TITLE
Add a ROI model/view

### DIFF
--- a/mvc.py
+++ b/mvc.py
@@ -1,5 +1,7 @@
 """Example usage of new mvc pattern."""
 
+from collections.abc import Sequence
+
 import numpy as np
 from qtpy.QtWidgets import QApplication
 
@@ -13,4 +15,15 @@ viewer = ViewerController()  # ultimately, this will be the public api
 # viewer.data = data.cosem_dataset(level=5)
 viewer.data = np.tile(data.cells3d(), (2, 1, 3, 4))
 viewer._view.show()
+
+
+def foo(
+    new: tuple[Sequence[float], Sequence[float]],
+    old: tuple[Sequence[float], Sequence[float]],
+) -> None:
+    print(f"Bounding box changed from {old} to {new}")
+
+
+viewer.roi.events.bounding_box.connect(foo)
+viewer.roi.bounding_box = ([10, 10], [100, 100])
 app.exec()

--- a/src/ndv/_old_viewer.py
+++ b/src/ndv/_old_viewer.py
@@ -680,6 +680,7 @@ class NDViewer(QWidget):
 
     def _press_element(self, event: QMouseEvent) -> bool:
         ev_pos = (event.position().x(), event.position().y())
+        print(f"Event position: {ev_pos}")
         pos = self._canvas.canvas_to_world(ev_pos)
         # TODO why does the canvas need this point untransformed??
         elements = self._canvas.elements_at(ev_pos)

--- a/src/ndv/models/__init__.py
+++ b/src/ndv/models/__init__.py
@@ -3,6 +3,13 @@
 from ._array_display_model import ArrayDisplayModel
 from ._data_display_model import DataDisplayModel
 from ._lut_model import LUTModel
+from ._roi_model import ROIModel
 from .data_wrappers._data_wrapper import DataWrapper
 
-__all__ = ["ArrayDisplayModel", "LUTModel", "DataDisplayModel", "DataWrapper"]
+__all__ = [
+    "ArrayDisplayModel",
+    "LUTModel",
+    "DataDisplayModel",
+    "ROIModel",
+    "DataWrapper",
+]

--- a/src/ndv/models/_roi_model.py
+++ b/src/ndv/models/_roi_model.py
@@ -1,0 +1,38 @@
+from collections.abc import Sequence
+from typing import Self
+
+from pydantic import model_validator
+
+from ndv.models._base_model import NDVModel
+
+
+class ROIModel(NDVModel):
+    """Representation of how to display a region of interest (ROI).
+    For now,
+    # TODO: Consider additional parameters for non-rectangle ROIs.
+
+    Parameters
+    ----------
+    visible : bool
+        Whether to display this roi.
+    bounding_box: tuple[Sequence[float], Sequence[float]]
+        The minimum point and the maximum point contained within the region.
+        Using these two points, an axis-aligned bounding box can be constructed.
+    """
+
+    visible: bool = True
+    bounding_box: tuple[Sequence[float], Sequence[float]] = ([0, 0], [0, 0])
+
+    @model_validator(mode="after")
+    def _validate_model(self) -> Self:
+        mi, ma = self.bounding_box
+        if len(mi) != len(ma):
+            raise ValueError(
+                "Minimum and maximum do not share the same number of dimensions"
+            )
+        for i in range(len(mi)):
+            if mi[i] > ma[i]:
+                # TODO: Could we switch min and max?
+                raise ValueError(f"Minimum is greater than maximum at index {i}")
+
+        return self

--- a/src/ndv/views/protocols.py
+++ b/src/ndv/views/protocols.py
@@ -28,6 +28,12 @@ class PLutView(Protocol):
     def setLutVisible(self, visible: bool) -> None: ...
 
 
+class PRoiView(Protocol):
+    boundingBoxChanged: Signal
+
+    def setBoundingBox(self, min: Sequence[int], max: Sequence[int]) -> None: ...
+
+
 class CanvasElement(Protocol):
     """Protocol defining an interactive element on the Canvas."""
 
@@ -93,6 +99,7 @@ class PView(Protocol):
     """Protocol that front-end viewers must implement."""
 
     currentIndexChanged: SignalInstance
+    boundingBoxChanged: SignalInstance
 
     def refresh(self) -> None: ...
     def create_sliders(self, coords: Mapping[int, Sequence]) -> None: ...


### PR DESCRIPTION
This PR provides a `ROIModel` class to maintain state about regions of interest, as well as a `PRoiView` protocol for views to implement when they want to react to changes in a `ROIModel`. This PR is by no means ready for merge, but exists for visibility and discussion about what is needed here.

For now, I'll edit `mvc.py` to include a (rectangular) ROI - next steps are to make it movable/resizable

Running points of discussion:
* What attributes are needed for the `ROIModel`? For a ND rectangular ROI, all we really need is minimum and maximum points in N dimensions, but thinking more broadly about lines, ellipses, freehand ROI selections, we might want more here. One idea I kind of like is an attribute that can provide a field of positions - something like imglib2's `IterableRegion`.
* Should `ROIModel` itself be a protocol that e.g. `RectangularROIModel`, `LineROIModel`, etc. implement?